### PR TITLE
Create room channel

### DIFF
--- a/lib/jointed_signaling_server_web/channels/room_channel.ex
+++ b/lib/jointed_signaling_server_web/channels/room_channel.ex
@@ -1,0 +1,12 @@
+defmodule JointedSignalingServerWeb.RoomChannel do
+  use Phoenix.Channel
+
+  def join("room:" <> _room_id, _params, socket) do
+    {:ok, socket}
+  end
+
+  def handle_in("new_msg", %{"body" => body}, socket) do
+    broadcast!(socket, "new_msg", %{body: body})
+    {:noreply, socket}
+  end
+end

--- a/lib/jointed_signaling_server_web/channels/user_socket.ex
+++ b/lib/jointed_signaling_server_web/channels/user_socket.ex
@@ -2,8 +2,8 @@ defmodule JointedSignalingServerWeb.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "room:*", JointedSignalingServerWeb.RoomChannel
   channel "user", JointedSignalingServerWeb.UserChannel
+  channel "room:*", JointedSignalingServerWeb.RoomChannel
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/test/jointed_signaling_server_web/channels/room_channel_test.exs
+++ b/test/jointed_signaling_server_web/channels/room_channel_test.exs
@@ -1,0 +1,41 @@
+defmodule JointedSignalingServerWeb.RoomChannelTest do
+  use JointedSignalingServerWeb.ChannelCase, async: true
+  alias JointedSignalingServerWeb.RoomChannel
+  alias JointedSignalingServerWeb.UserSocket
+
+  setup do
+    {:ok, _, socket} =
+      UserSocket
+      |> socket(%{}, %{})
+      |> subscribe_and_join(RoomChannel, "room:test")
+
+    %{socket: socket}
+  end
+
+  #
+  # Unit tests
+  #
+
+  test "join room" do
+    {:ok, socket} = connect(UserSocket, %{}, %{})
+    assert {:ok, socket} = RoomChannel.join("room:123", %{}, socket)
+  end
+
+  test "handle_in on new_msg event", %{socket: socket} do
+    assert {:noreply, socket} = RoomChannel.handle_in("new_msg", %{"body" => %{}}, socket)
+  end
+
+  #
+  # Integration tests
+  #
+
+  test "new_msg broadcasts into pubsub", %{socket: socket} do
+    push(socket, "new_msg", %{"body" => "test"})
+    assert_broadcast "new_msg", %{body: "test"}
+  end
+
+  test "connected clients receive new_msg", %{socket: socket} do
+    push(socket, "new_msg", %{"body" => "test"})
+    assert_push "new_msg", %{body: "test"}
+  end
+end


### PR DESCRIPTION
With this commit, clients connected via websocket can exchange messages
by joining a room.